### PR TITLE
fix gunicorn worker to works with unix sock files

### DIFF
--- a/muffin/worker.py
+++ b/muffin/worker.py
@@ -75,9 +75,10 @@ class GunicornWorker(GunicornWebWorker):
         self.loop.run_until_complete(app.start())
         super(GunicornWorker, self).run()
 
-    def make_handler(self, app, host, port):
+    def make_handler(self, app, *args):
         handler = app.make_handler(
-            host=host, port=port, logger=self.log,
-            debug=app.cfg.DEBUG, keep_alive=self.cfg.keepalive, timeout=self.cfg.timeout,
-            access_log=self.log.access_log, access_log_format=self.cfg.access_log_format)
+            logger=self.log, debug=app.cfg.DEBUG,
+            keep_alive=self.cfg.keepalive, timeout=self.cfg.timeout,
+            access_log=self.log.access_log,
+            access_log_format=self.cfg.access_log_format)
         return handler


### PR DESCRIPTION
I try to deploy my application with nginx and muffin with sock file, but it raised this error:
```python
  File "/home/arcoiro/venv/lib/python3.4/site-packages/aiohttp/worker.py", line 81, in _run
    handler = self.make_handler(self.wsgi, *sock.cfg_addr)
TypeError: make_handler() takes 4 positional arguments but 11 were given
```
I start the application with this command (or something like this)
```bash
$ muffin my_app run --bind unix:my_sock.sock
```
This changes in muffin gunicorn worker solved it to me.