### PR TITLE
Fix route names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ pip-log.txt
 .tox
 nosetests.xml
 
+# py.test lastfailed cache
+.cache
+
 # Translations
 *.mo
 

--- a/muffin/urls.py
+++ b/muffin/urls.py
@@ -86,7 +86,7 @@ def routes_register(app, view, *paths, methods=None, router=None, name=''):
                 # Fix route name
                 cname, num = name, 1
                 while cname in router:
-                    cname = name + "-" + str(num)
+                    cname = "%s%d" % (name, num)
                     num += 1
                 name = cname
 

--- a/muffin/urls.py
+++ b/muffin/urls.py
@@ -82,15 +82,17 @@ def routes_register(app, view, *paths, methods=None, router=None, name=''):
                 app._error_handlers[path] = view
                 continue
 
-            # Fix route name
-            cname, num = name + "-" + method.lower(), 1
-            while cname in router:
-                cname = name + "-" + str(num)
-                num += 1
+            if name in router:
+                # Fix route name
+                cname, num = name, 1
+                while cname in router:
+                    cname = name + "-" + str(num)
+                    num += 1
+                name = cname
 
             # Support regexpa in paths
             if isinstance(path, RETYPE):
-                router.register_route(RawReRoute(method.upper(), view, cname, path))
+                router.register_route(RawReRoute(method.upper(), view, name, path))
                 continue
 
             # Support custom methods
@@ -98,4 +100,4 @@ def routes_register(app, view, *paths, methods=None, router=None, name=''):
             if method not in router.METHODS:
                 router.METHODS.add(method)
 
-            router.add_route(method, path, view, name=cname)
+            router.add_route(method, path, view, name=name)

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -7,7 +7,6 @@ def test_handler_func(app, client):
     @app.register('/test')
     def test(request):
         return 'TEST PASSED'
-    assert 'test-*' in app.router._routes
 
     response = client.get('/test')
     assert response.text == 'TEST PASSED'
@@ -15,12 +14,13 @@ def test_handler_func(app, client):
     response = client.post('/test')
     assert response.text == 'TEST PASSED'
 
+    assert app.router['test'].url() == '/test'
+
     @app.register('/test1', methods='get')
     def test1(request):
         return 'TEST PASSED'
 
-    assert 'test1-get' in app.router._routes
-    assert 'test1-post' not in app.router._routes
+    assert app.router['test1'].url() == '/test1'
 
     response = client.get('/test1')
     assert response.text == 'TEST PASSED'
@@ -29,14 +29,13 @@ def test_handler_func(app, client):
     def test2(request):
         return 'TEST PASSED'
 
-    assert 'test2-get' in app.router._routes
-    assert 'test2-post' in app.router._routes
+    assert app.router['test2'].url() == '/test2'
 
     @app.register('/test3', methods='*')
     def test3(request):
         return 'TEST PASSED'
 
-    assert 'test3-*' in app.router._routes
+    assert app.router['test3'].url() == '/test3'
     response = client.get('/test3')
     assert response.status_code == 200
 
@@ -63,7 +62,8 @@ def test_handler(app, client):
     assert set(Resource.methods) == set(['GET', 'POST'])
     assert asyncio.iscoroutinefunction(Resource.get)
 
-    assert 'resource-*' in app.router._routes
+    assert app.router['resource'].url(parts={'res': 1}) == '/res/1'
+    assert 'resource-1' in app.router._routes
 
     response = client.delete('/res', status=405)
 


### PR DESCRIPTION
It is better to specify HTTP method name in URL route name explicitly, than
append it to all endpoints.

Nice get/post/etc endpoint names could be generated in explicit manner
automatically, if one would use the flask_classy-like views.

Implementation of such view could be found here: http://github.com/ei-grad/muffin-classy