### PR TITLE
changed virtualenv command to pyvenv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ upload: clean
 # =============
 
 $(VIRTUAL_ENV): requirements.txt
-	@[ -d $(VIRTUAL_ENV) ] || virtualenv --no-site-packages $(VIRTUAL_ENV)
+	@[ -d $(VIRTUAL_ENV) ] || pyvenv $(VIRTUAL_ENV)
 	@$(VIRTUAL_ENV)/bin/pip install -r requirements.txt
 	@touch $(VIRTUAL_ENV)
 


### PR DESCRIPTION
Problem: I have installed python 2.7 and 3.5. When I run the make task `test` it uses my python 2.7 to create the environment folder (`.env`) and of course, return me errors because the python 3 dependencies.

Cause: The task `test` on Makefile run the command `virtualenv` to create the environment and it uses the current `python` command, witch in my case is python 2.7.9.

Solution: Python 3 comes with a new command `pyvenv` that creates a python 3 virtual environment with pip. Changing it in the `Makefile` ensures that the tests environment will have the correct python version and run correctly without errors on systems with both python 2 and 3 versions installed.