### PR TITLE
Transfer digestmode

### DIFF
--- a/muffin/utils.py
+++ b/muffin/utils.py
@@ -50,7 +50,7 @@ def create_signature(secret, value, digestmod='sha1', encoding='utf-8'):
     if isinstance(digestmod, str):
         digestmod = getattr(hashlib, digestmod, hashlib.sha1)
 
-    hm = hmac.new(secret, digestmod=hashlib.sha1)
+    hm = hmac.new(secret, digestmod=digestmod)
     hm.update(value)
     return hm.hexdigest()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,13 +66,27 @@ def test_struct():
         settings.test = 42
 
 
-def test_import_submodules():
-    from muffin import import_submodules
+def test_generate_password_hash_default():
+    from muffin.utils import generate_password_hash, check_password_hash
 
-    result = import_submodules('muffin')
-    assert len(result) == 8
+    password = '#secret$'
+    password_hash = generate_password_hash(password, digestmod='sha1', salt_length=8)
 
-    result = import_submodules('muffin', 'plugins', 'manage')
-    assert len(result) == 2
+    assert password_hash.startswith('sha1')
+    assert len(password_hash.split('$')[1]) == 8
+    assert len(password_hash.split('$')[2]) == 40
+    assert check_password_hash(password, password_hash)
+
+
+def test_generate_password_hash_sha256():
+    from muffin.utils import generate_password_hash, check_password_hash
+
+    password = '#secret$'
+    password_hash = generate_password_hash(password, digestmod='sha256', salt_length=20)
+
+    assert password_hash.startswith('sha256')
+    assert len(password_hash.split('$')[1]) == 20
+    assert len(password_hash.split('$')[2]) == 64
+    assert check_password_hash(password, password_hash)
 
 #  pylama:ignore=E0237

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -66,6 +66,16 @@ def test_struct():
         settings.test = 42
 
 
+def test_import_submodules():
+    from muffin import import_submodules
+
+    result = import_submodules('muffin')
+    assert len(result) == 8
+
+    result = import_submodules('muffin', 'plugins', 'manage')
+    assert len(result) == 2
+
+
 def test_generate_password_hash_default():
     from muffin.utils import generate_password_hash, check_password_hash
 


### PR DESCRIPTION
Hi, this PR fixes transferring missed `digestmode` to hashing function and adds simple tests to cover password hashing function.

Also I wanted to suggest to use sha256 by default.


Привет, заметил что пропустили передачу 'digestmode', что может приводит к ошибкам распознавания хеша.
Добавил тесты для поверхностного тестирования. Извиняюсь за лишний коммит из-за случайно удаленного теста...
Также хотел предложить поменять дефолтный алгоритм шифрования на sha256.