### PR TITLE
Error exec command line in terminal. 

### DIFF
--- a/muffin/manage.py
+++ b/muffin/manage.py
@@ -260,12 +260,12 @@ def run():
     app_uri = args_.app
     if ':' not in app_uri:
         app_uri += ':app'
-        try:
-            app = import_app(app_uri)
-            app.logger.info('Application is loaded: %s' % app.name)
-        except Exception as exc:
-            logging.exception(exc)
-            raise sys.exit(1)
+    try:
+        app = import_app(app_uri)
+        app.logger.info('Application is loaded: %s' % app.name)
+    except Exception as exc:
+        logging.exception(exc)
+        raise sys.exit(1)
 
     app.manage(*subargs_, prog='muffin %s' % args_.app)
 


### PR DESCRIPTION
I had problem with this command line ```muffin example:app create [NAME]```.
This was the error:
```    app.manage(*subargs_, prog='muffin %s' % args_.app)
UnboundLocalError: local variable 'app' referenced before assignment```
This problem was solved for me changing the code indentation on file  muffin/manage.py
