### PR TITLE
Fix unique route names generation algorithm

### DIFF
--- a/muffin/urls.py
+++ b/muffin/urls.py
@@ -151,7 +151,8 @@ def routes_register(app, handler, *paths, methods=None, router=None, name=None):
         name = str(name or '')
         rname, rnum = name, 2
         while rname in router:
-            rname = "%s%d" % (rname, rnum)
+            rname = "%s%d" % (name, rnum)
+            rnum += 1
 
         path = parse(path)
         if isinstance(path, RETYPE):

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -53,9 +53,8 @@ def test_register_url(app):
     def handler():
         pass
 
-    routes_register(app, handler,
-                    '/path/{id:\d+}', '/path/add', '/other/path',
-                    name='handler')
-    assert 'handler' in app.router
-    assert 'handler2' in app.router
-    assert 'handler3' in app.router
+    routes_register(app, handler, '/path/{id:\d+}', '/path/add', '/other/path', name='endpoint')
+
+    assert 'endpoint' in app.router and app.router['endpoint'].url(id=5) == '/path/5'
+    assert 'endpoint2' in app.router and app.router['endpoint2'].url() == '/path/add'
+    assert 'endpoint3' in app.router and app.router['endpoint3'].url() == '/other/path'

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -46,6 +46,7 @@ def test_parent(loop):
     assert parent.url() == '/api/'
     assert parent.url(name='test') == '/api/test/'
 
+
 def test_register_url(app):
     from muffin.urls import routes_register
 
@@ -53,7 +54,8 @@ def test_register_url(app):
         pass
 
     routes_register(app, handler,
-                    '/path/{id:\d+}', '/path/add', '/other/path')
+                    '/path/{id:\d+}', '/path/add', '/other/path',
+                    name='handler')
     assert 'handler' in app.router
     assert 'handler2' in app.router
     assert 'handler3' in app.router

--- a/tests/test_urls.py
+++ b/tests/test_urls.py
@@ -45,3 +45,15 @@ def test_parent(loop):
 
     assert parent.url() == '/api/'
     assert parent.url(name='test') == '/api/test/'
+
+def test_register_url(app):
+    from muffin.urls import routes_register
+
+    def handler():
+        pass
+
+    routes_register(app, handler,
+                    '/path/{id:\d+}', '/path/add', '/other/path')
+    assert 'handler' in app.router
+    assert 'handler2' in app.router
+    assert 'handler3' in app.router


### PR DESCRIPTION
In current implementation, when one registers one handler for several urls (using e.g. `@app.register('/url1', '/url2', '/url3')`), Muffin creates unique route names by appending `2` to existing name until resulting name is unique. This results in route names like `myroute`, `myroute2`, `myroute22` etc., up to `myroute22222222`.
I suppose it was initially intended to behave as `myroute`, `myroute2`, `myroute3` etc. So I implemented such change and added tests for it.

This has a downside of behaviour changing, so that constructs like `return HTTPFound(app.router['myroute222'].url())` will stop working. But maybe we can handle it somehow?..