### PR TITLE
Remove deprecated django_settings variable from worker.py

### DIFF
--- a/muffin/worker.py
+++ b/muffin/worker.py
@@ -42,7 +42,6 @@ class GunicornApp(VanillaGunicornApp):
 
         # Remove unused settings
         del self.cfg.settings['paste']
-        del self.cfg.settings['django_settings']
 
         self.cfg.settings['worker_class'].default = (
             'muffin.worker.GunicornWorker'


### PR DESCRIPTION
#53 As i've mentioned in that issue, `gunicorn` has deprecated `django_settings` on its version `19.7.0`. This issue was stopping it of running any app on muffin it raised `Error: 'django_settings'`

This PR removes it.  

There aren't any tests covering `worker.py` for now.